### PR TITLE
Fixed bug

### DIFF
--- a/lib/delocalize/rails_ext/active_record_rails42.rb
+++ b/lib/delocalize/rails_ext/active_record_rails42.rb
@@ -49,7 +49,7 @@ ActiveRecord::Base.class_eval do
             time = time.is_a?(String) ? (I18n.delocalization_enabled? ? Time.zone.parse_localized(time) : Time.zone.parse(time)) : time.to_time rescue time
           end
           time = time.in_time_zone rescue nil if time
-          write_attribute(:#{attr_name}, original_time)
+          write_attribute(:#{attr_name}, time)
         end
       EOV
       generated_attribute_methods.module_eval(method_body, __FILE__, line)


### PR DESCRIPTION
When I worked with  https://coupadev.atlassian.net/browse/CD-51722 i found bug(to my opinion).
We should use `time` (does not `original_time`)
- [x] @johnny-lai 
