### PR TITLE
Fixed type_cast to render action_view helpers

### DIFF
--- a/lib/delocalize/rails_ext/action_view.rb
+++ b/lib/delocalize/rails_ext/action_view.rb
@@ -1,4 +1,6 @@
-if Gem::Version.new(ActionPack::VERSION::STRING) >= Gem::Version.new('4.0.0.beta')
+if Gem::Version.new(ActionPack::VERSION::STRING) >= Gem::Version.new('4.2')
+  require 'delocalize/rails_ext/action_view_rails42'
+elsif Gem::Version.new(ActionPack::VERSION::STRING) >= Gem::Version.new('4.0.0.beta')
   require 'delocalize/rails_ext/action_view_rails4'
 else
   require 'delocalize/rails_ext/action_view_rails3'

--- a/lib/delocalize/rails_ext/action_view_rails42.rb
+++ b/lib/delocalize/rails_ext/action_view_rails42.rb
@@ -1,0 +1,39 @@
+require 'action_view'
+
+# TODO: also override other methods like to_check_box_tag since they might contain numeric values?
+# ActionView needs some patching too
+
+ActionView::Helpers::Tags::TextField.class_eval do
+  include ActionView::Helpers::NumberHelper
+
+  def render_with_localization
+    if object && (@options[:value].blank? || !@options[:value].is_a?(String)) && object.respond_to?(:column_for_attribute) && column = object.column_for_attribute(@method_name)
+      value = @options[:value] || object.send(@method_name)
+
+      if column.number?
+        number_options = I18n.t(:'number.format')
+        separator = @options.delete(:separator) || number_options[:separator]
+        delimiter = @options.delete(:delimiter) || number_options[:delimiter]
+        precision = @options.delete(:precision) || number_options[:precision]
+        opts = { :separator => separator, :delimiter => delimiter, :precision => precision }
+        is_integer = (column.type == :integer) || column.cast_type.is_a?(ActiveRecord::Type::DecimalWithoutScale)
+        # integers don't need a precision
+        opts.merge!(:precision => 0) if is_integer
+
+        hidden_for_integer = field_type == 'hidden' && is_integer
+
+        # the number will be formatted only if it has no numericality errors
+        if object.respond_to?(:errors) && !Array(object.errors[@method_name]).try(:include?, 'is not a number')
+          # we don't format integer hidden fields because this breaks nested_attributes
+          @options[:value] = number_with_precision(value, opts) unless hidden_for_integer
+        end
+      elsif column.date? || column.time?
+        @options[:value] = value ? I18n.l(value, :format => @options.delete(:format)) : nil
+      end
+    end
+
+    render_without_localization
+  end
+
+  alias_method_chain :render, :localization
+end


### PR DESCRIPTION
https://coupadev.atlassian.net/browse/CD-52209
- [x] @johnny-lai 

I will try to explain this issue. It is problem with new typecast aproach. 
In rails 4.1 we have this line 'https://github.com/rails/rails/blob/4-1-stable/activerecord/lib/active_record/connection_adapters/column.rb#L36'
In this line we are converting `sql_type` to `type`. When we have sql_type like `decimal(10,0)` then type will be `:integer`.

``` ruby
[1] pry(#<ActiveRecord::ConnectionAdapters::Mysql2Adapter::Column>)> sql_type
=> "decimal(10,0)"
[2] pry(#<ActiveRecord::ConnectionAdapters::Mysql2Adapter::Column>)> simplified_type(sql_type)
=> :integer
```

Here is column object: 

``` ruby
[8] pry(#<ActionView::Helpers::Tags::TextField>)> column
=> #<ActiveRecord::ConnectionAdapters::Mysql2Adapter::Column:0x0000000ac221f8
 @coder=nil,
 @collation=nil,
 @default=nil,
 @default_function=nil,
 @extra="",
 @limit=10,
 @name="ss_qty_pct_po_tolerance",
 @null=true,
 @precision=10,
 @primary=false,
 @scale=0,
 @sql_type="decimal(10,0)",
 @strict=false,
 @type=:integer>
```

Thats why in `delocalize` gem we are comparing `type` of field (https://github.com/johnny-lai/delocalize/blob/0-4-coupa_CD-37836/lib/delocalize/rails_ext/action_view_rails4.rb#L20)

But in rails 4.2 behaviors was changed. 
Here is colum object

``` ruby
[6] pry(#<ActionView::Helpers::Tags::TextField>)> column
=> #<ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter::Column:0x0000000cd40ce0
 @cast_type=#<ActiveRecord::Type::DecimalWithoutScale:0x0000000cd22f60 @limit=nil, @precision=10, @range=-Infinity...Infinity, @scale=nil>,
 @collation=nil,
 @default=nil,
 @default_function=nil,
 @extra="",
 @name="ss_qty_pct_po_tolerance",
 @null=true,
 @sql_type="decimal(10,0)",
 @strict=true>

```

Now we have `cast_type` param `ActiveRecord::Type::DecimalWithoutScale`. And it has type like `:decimal` (https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/type/decimal_without_scale.rb#L7). 

But we need that this `type` will be `:integer`. 

So I decided to add code to `delocalize` gem(If we have type like integer or type_cast is ActiveRecord::Type::DecimalWithoutScale then `precision = 0` )

I copied action_view_rails4.rb to action_view_rails42.rb and chaged 3 lines. I marked lines below.
